### PR TITLE
Add rich pattern form and navigation links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+bin/
+obj/
+*.user
+*.suo
+*.exe
+*.dll
+*.pdb

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The main goal is to set up the foundation for a future community platform for sh
 - `src/PatronProPartage` — Minimal Blazor Server project skeleton.
 - `src/PatronProPartage/Models` — Data models.
 - `src/PatronProPartage/Services` — Service interfaces and stubs.
-- `src/PatronProPartage/Pages` — Razor components/pages.
+- `src/PatronProPartage/Pages` — Razor components/pages. Includes basic forms and a pattern details view.
 - `src/PatronProPartage/Shared` — Shared layout components.
 
 This code does **not** build or run in this environment because the .NET SDK is missing. However, it provides an outline of the intended architecture.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# PatronProPartage
+
+Skeleton for the "PatronProPartage" Blazor Server project. This repository only contains a minimal set of files to provide an initial structure, as the full application requires tooling not available in this environment.
+
+The main goal is to set up the foundation for a future community platform for sharing sewing patterns. The stack is intended to be Blazor Server with MudBlazor components, using a local SQL Server database and file storage. Basic ASP.NET Core Identity with role support is now configured using an in-memory database.
+
+## Structure
+
+- `src/PatronProPartage` — Minimal Blazor Server project skeleton.
+- `src/PatronProPartage/Models` — Data models.
+- `src/PatronProPartage/Services` — Service interfaces and stubs.
+- `src/PatronProPartage/Pages` — Razor components/pages.
+- `src/PatronProPartage/Shared` — Shared layout components.
+
+This code does **not** build or run in this environment because the .NET SDK is missing. However, it provides an outline of the intended architecture.
+
+## Future setup
+
+Once a .NET development environment is available, you can run `dotnet restore` and `dotnet build` to compile the project. MudBlazor should be added as a package reference, and the service implementations should be completed to interact with the database and file system.

--- a/src/PatronProPartage/App.razor
+++ b/src/PatronProPartage/App.razor
@@ -1,0 +1,13 @@
+<CascadingAuthenticationState>
+    <Router AppAssembly="typeof(Program).Assembly">
+        <Found Context="routeData">
+            <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+            <FocusOnNavigate RouteData="routeData" Selector="h1" />
+        </Found>
+        <NotFound>
+            <LayoutView Layout="typeof(MainLayout)">
+                <p>Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/src/PatronProPartage/Data/AppDbContext.cs
+++ b/src/PatronProPartage/Data/AppDbContext.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using PatronProPartage.Models;
+
+namespace PatronProPartage.Data;
+
+public class AppDbContext : IdentityDbContext<ApplicationUser>
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Pattern> Patterns => Set<Pattern>();
+}

--- a/src/PatronProPartage/Data/IdentityDataInitializer.cs
+++ b/src/PatronProPartage/Data/IdentityDataInitializer.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Identity;
+using PatronProPartage.Models;
+
+namespace PatronProPartage.Data;
+
+public static class IdentityDataInitializer
+{
+    public static async Task SeedAsync(UserManager<ApplicationUser> userManager,
+                                       RoleManager<IdentityRole> roleManager)
+    {
+        string[] roles = new[] { "Admin", "Moderator", "Premium", "Contributor", "User" };
+
+        foreach (var role in roles)
+        {
+            if (!await roleManager.RoleExistsAsync(role))
+            {
+                await roleManager.CreateAsync(new IdentityRole(role));
+            }
+        }
+
+        // Additional seeding like creating a default admin user could be placed here
+    }
+}

--- a/src/PatronProPartage/Models/ApplicationUser.cs
+++ b/src/PatronProPartage/Models/ApplicationUser.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace PatronProPartage.Models;
+
+public class ApplicationUser : IdentityUser
+{
+    // Additional properties specific to the domain can be added here later
+}

--- a/src/PatronProPartage/Models/Badge.cs
+++ b/src/PatronProPartage/Models/Badge.cs
@@ -1,0 +1,8 @@
+namespace PatronProPartage.Models;
+
+public class Badge
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Icon { get; set; } = string.Empty;
+}

--- a/src/PatronProPartage/Models/Library.cs
+++ b/src/PatronProPartage/Models/Library.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+namespace PatronProPartage.Models;
+
+public class Library
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool IsPublic { get; set; }
+    public List<Pattern> Patterns { get; set; } = new();
+}

--- a/src/PatronProPartage/Models/Pattern.cs
+++ b/src/PatronProPartage/Models/Pattern.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+namespace PatronProPartage.Models;
+
+public class Pattern
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public List<string> ClothingCategories { get; set; } = new();
+    public List<string> Techniques { get; set; } = new();
+    public List<string> Sizes { get; set; } = new();
+    public List<string> Seasons { get; set; } = new();
+    public List<string> Styles { get; set; } = new();
+    public List<string> Formats { get; set; } = new();
+    public List<string> Files { get; set; } = new();
+    public List<string> Images { get; set; } = new();
+    public string? Video { get; set; }
+    public double AverageRating { get; set; }
+    public List<string> Comments { get; set; } = new();
+    public User? Author { get; set; }
+    public List<PatternVersion> Versions { get; set; } = new();
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/src/PatronProPartage/Models/PatternVersion.cs
+++ b/src/PatronProPartage/Models/PatternVersion.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace PatronProPartage.Models;
+
+public class PatternVersion
+{
+    public int Id { get; set; }
+    public DateTime Date { get; set; }
+    public List<string> Files { get; set; } = new();
+    public string? Note { get; set; }
+}

--- a/src/PatronProPartage/Models/PrivateMessage.cs
+++ b/src/PatronProPartage/Models/PrivateMessage.cs
@@ -1,0 +1,11 @@
+using System;
+namespace PatronProPartage.Models;
+
+public class PrivateMessage
+{
+    public int Id { get; set; }
+    public int SenderId { get; set; }
+    public int RecipientId { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public DateTime SentAt { get; set; }
+}

--- a/src/PatronProPartage/Models/User.cs
+++ b/src/PatronProPartage/Models/User.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+namespace PatronProPartage.Models;
+
+public class User
+{
+    public int Id { get; set; }
+    public string Pseudo { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+    public List<Library> Libraries { get; set; } = new();
+    public List<Pattern> Patterns { get; set; } = new();
+    public List<PrivateMessage> Messages { get; set; } = new();
+    public UserRole Role { get; set; } = UserRole.Utilisateur;
+    public List<Badge> Badges { get; set; } = new();
+}

--- a/src/PatronProPartage/Models/UserRole.cs
+++ b/src/PatronProPartage/Models/UserRole.cs
@@ -1,0 +1,10 @@
+namespace PatronProPartage.Models;
+
+public enum UserRole
+{
+    Utilisateur,
+    Contributeur,
+    Premium,
+    Moderateur,
+    Admin
+}

--- a/src/PatronProPartage/Pages/Index.razor
+++ b/src/PatronProPartage/Pages/Index.razor
@@ -1,0 +1,5 @@
+@page "/"
+
+<MudText Typo="Typo.h4">Welcome to PatronProPartage</MudText>
+<MudText>Ce projet est un squelette de plateforme communautaire pour partager des patrons de couture.</MudText>
+

--- a/src/PatronProPartage/Pages/PatternDetail.razor
+++ b/src/PatronProPartage/Pages/PatternDetail.razor
@@ -1,0 +1,35 @@
+@page "/pattern/{id:int}"
+@inject IPatronService PatronService
+
+@if (_pattern == null)
+{
+    <MudText>Patron introuvable.</MudText>
+}
+else
+{
+    <MudPaper Class="pa-4" Elevation="2">
+        <MudText Typo="Typo.h5">@_pattern.Name</MudText>
+        <MudText Typo="Typo.subtitle2">@_pattern.Description</MudText>
+        <MudDivider Class="my-2" />
+        <MudChipSet>
+            @foreach (var cat in _pattern.ClothingCategories)
+            {
+                <MudChip>@cat</MudChip>
+            }
+        </MudChipSet>
+        <MudText Typo="Typo.caption" Class="mt-2">Tailles: @string.Join(", ", _pattern.Sizes)</MudText>
+        <MudText Typo="Typo.caption">Saisons: @string.Join(", ", _pattern.Seasons)</MudText>
+    </MudPaper>
+}
+
+@code {
+    [Parameter]
+    public int id { get; set; }
+
+    private Pattern? _pattern;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _pattern = await PatronService.GetByIdAsync(id);
+    }
+}

--- a/src/PatronProPartage/Pages/PatternForm.razor
+++ b/src/PatronProPartage/Pages/PatternForm.razor
@@ -1,0 +1,90 @@
+@page "/patternform"
+@inject IPatronService PatronService
+@using System
+
+<MudPaper Class="pa-4" Elevation="3">
+    <MudText Typo="Typo.h6">Ajouter un patron</MudText>
+    <EditForm Model="_pattern" OnValidSubmit="HandleValidSubmit">
+        <MudTextField @bind-Value="_pattern.Name" Label="Nom" Required="true" />
+        <MudTextField @bind-Value="_pattern.Description" Label="Description" Lines="3" />
+
+        <MudSelect T="string" Label="Catégories" MultiSelection="true" @bind-SelectedValues="_pattern.ClothingCategories">
+            @foreach (var item in ClothingOptions)
+            {
+                <MudSelectItem Value="@item">@item</MudSelectItem>
+            }
+        </MudSelect>
+
+        <MudSelect T="string" Label="Techniques" MultiSelection="true" @bind-SelectedValues="_pattern.Techniques">
+            @foreach (var item in TechniqueOptions)
+            {
+                <MudSelectItem Value="@item">@item</MudSelectItem>
+            }
+        </MudSelect>
+
+        <MudSelect T="string" Label="Tailles" MultiSelection="true" @bind-SelectedValues="_pattern.Sizes">
+            @foreach (var item in SizeOptions)
+            {
+                <MudSelectItem Value="@item">@item</MudSelectItem>
+            }
+        </MudSelect>
+
+        <MudSelect T="string" Label="Saisons" MultiSelection="true" @bind-SelectedValues="_pattern.Seasons">
+            @foreach (var item in SeasonOptions)
+            {
+                <MudSelectItem Value="@item">@item</MudSelectItem>
+            }
+        </MudSelect>
+
+        <MudSelect T="string" Label="Styles" MultiSelection="true" @bind-SelectedValues="_pattern.Styles">
+            @foreach (var item in StyleOptions)
+            {
+                <MudSelectItem Value="@item">@item</MudSelectItem>
+            }
+        </MudSelect>
+
+        <InputFile OnChange="FilesSelected" Multiple="true" />
+        <MudTextField @bind-Value="_pattern.Video" Label="Vidéo YouTube" />
+
+        @if (_imagePreview != null)
+        {
+            <img src="@_imagePreview" style="max-width:200px" />
+        }
+
+        <MudButton Color="Color.Primary" Type="Submit">Enregistrer</MudButton>
+    </EditForm>
+</MudPaper>
+
+@code {
+    private Pattern _pattern = new();
+    private string? _imagePreview;
+
+    private static readonly string[] ClothingOptions = { "Jupe", "Haut", "Pantalon", "Robe" };
+    private static readonly string[] TechniqueOptions = { "Plis", "Couture anglaise", "Surjet" };
+    private static readonly string[] SizeOptions = { "XS", "S", "M", "L", "XL", "XXL" };
+    private static readonly string[] SeasonOptions = { "Été", "Hiver", "Printemps", "Automne" };
+    private static readonly string[] StyleOptions = { "Chic", "Sobre", "Street" };
+
+    private async Task FilesSelected(InputFileChangeEventArgs e)
+    {
+        foreach (var file in e.GetMultipleFiles())
+        {
+            _pattern.Files.Add(file.Name);
+            if (file.ContentType.StartsWith("image/") && _imagePreview == null)
+            {
+                var buffer = new byte[file.Size];
+                await file.OpenReadStream().ReadAsync(buffer);
+                _imagePreview = $"data:{file.ContentType};base64,{Convert.ToBase64String(buffer)}";
+            }
+        }
+    }
+
+    private async Task HandleValidSubmit()
+    {
+        _pattern.CreatedAt = DateTime.UtcNow;
+        _pattern.UpdatedAt = DateTime.UtcNow;
+        await PatronService.AddAsync(_pattern);
+        _pattern = new();
+        _imagePreview = null;
+    }
+}

--- a/src/PatronProPartage/Pages/Patterns.razor
+++ b/src/PatronProPartage/Pages/Patterns.razor
@@ -9,7 +9,9 @@
 <MudList>
     @foreach (var pattern in _patterns)
     {
-        <MudListItem>@pattern.Name</MudListItem>
+        <MudListItem>
+            <MudLink Href=$"/pattern/{pattern.Id}">@pattern.Name</MudLink>
+        </MudListItem>
     }
 </MudList>
 

--- a/src/PatronProPartage/Pages/Patterns.razor
+++ b/src/PatronProPartage/Pages/Patterns.razor
@@ -1,0 +1,23 @@
+@using PatronProPartage.Models
+@using System.Collections.Generic
+@using System.Linq
+@page "/patterns"
+@inject IPatronService PatronService
+
+<MudText Typo="Typo.h5">Patrons disponibles</MudText>
+
+<MudList>
+    @foreach (var pattern in _patterns)
+    {
+        <MudListItem>@pattern.Name</MudListItem>
+    }
+</MudList>
+
+@code {
+    private IEnumerable<Pattern> _patterns = Enumerable.Empty<Pattern>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        _patterns = await PatronService.GetAllAsync();
+    }
+}

--- a/src/PatronProPartage/Pages/Profile.razor
+++ b/src/PatronProPartage/Pages/Profile.razor
@@ -1,0 +1,4 @@
+@page "/profile"
+
+<MudText Typo="Typo.h5">Mon profil</MudText>
+<MudText>Page de profil utilisateur (contenu à venir).</MudText>

--- a/src/PatronProPartage/Pages/_Host.cshtml
+++ b/src/PatronProPartage/Pages/_Host.cshtml
@@ -12,11 +12,13 @@
     <title>PatronProPartage</title>
     <base href="~" />
     <link href="css/site.css" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
 </head>
 <body>
     <app>
         <component type="typeof(App)" render-mode="ServerPrerendered" />
     </app>
     <script src="_framework/blazor.server.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 </body>
 </html>

--- a/src/PatronProPartage/Pages/_Host.cshtml
+++ b/src/PatronProPartage/Pages/_Host.cshtml
@@ -1,0 +1,22 @@
+@page "/"
+@namespace PatronProPartage.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PatronProPartage</title>
+    <base href="~" />
+    <link href="css/site.css" rel="stylesheet" />
+</head>
+<body>
+    <app>
+        <component type="typeof(App)" render-mode="ServerPrerendered" />
+    </app>
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/src/PatronProPartage/PatronProPartage.csproj
+++ b/src/PatronProPartage/PatronProPartage.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MudBlazor" Version="6.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/PatronProPartage/Program.cs
+++ b/src/PatronProPartage/Program.cs
@@ -24,7 +24,6 @@ builder.Services.AddMudServices();
 builder.Services.AddSingleton<IPatronService, InMemoryPatronService>();
 builder.Services.AddSingleton<IUserService, InMemoryUserService>();
 builder.Services.AddSingleton<IFileStorageService, LocalFileStorageService>();
-// MudBlazor services would be added here
 
 var app = builder.Build();
 

--- a/src/PatronProPartage/Program.cs
+++ b/src/PatronProPartage/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
+builder.Services.AddMudServices();
 builder.Services.AddSingleton<IPatronService, InMemoryPatronService>();
 builder.Services.AddSingleton<IUserService, InMemoryUserService>();
 builder.Services.AddSingleton<IFileStorageService, LocalFileStorageService>();

--- a/src/PatronProPartage/Program.cs
+++ b/src/PatronProPartage/Program.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using PatronProPartage.Data;
+using PatronProPartage.Models;
+using PatronProPartage.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Database context for Identity and other entities
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseInMemoryDatabase("PatronProPartage"));
+
+// ASP.NET Core Identity with role support
+builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
+    .AddEntityFrameworkStores<AppDbContext>()
+    .AddDefaultTokenProviders();
+
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+builder.Services.AddSingleton<IPatronService, InMemoryPatronService>();
+builder.Services.AddSingleton<IUserService, InMemoryUserService>();
+builder.Services.AddSingleton<IFileStorageService, LocalFileStorageService>();
+// MudBlazor services would be added here
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+app.MapRazorPages();
+
+await SeedRoles(app.Services);
+
+app.Run();
+
+static async Task SeedRoles(IServiceProvider services)
+{
+    using var scope = services.CreateScope();
+    var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+    var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+    await IdentityDataInitializer.SeedAsync(userManager, roleManager);
+}

--- a/src/PatronProPartage/Services/IFileStorageService.cs
+++ b/src/PatronProPartage/Services/IFileStorageService.cs
@@ -1,0 +1,8 @@
+namespace PatronProPartage.Services;
+
+public interface IFileStorageService
+{
+    Task SaveAsync(string path, Stream content);
+    Task<Stream?> GetAsync(string path);
+    Task DeleteAsync(string path);
+}

--- a/src/PatronProPartage/Services/IPatronService.cs
+++ b/src/PatronProPartage/Services/IPatronService.cs
@@ -1,0 +1,12 @@
+using PatronProPartage.Models;
+
+namespace PatronProPartage.Services;
+
+public interface IPatronService
+{
+    Task<List<Pattern>> GetAllAsync();
+    Task<Pattern?> GetByIdAsync(int id);
+    Task AddAsync(Pattern pattern);
+    Task UpdateAsync(Pattern pattern);
+    Task DeleteAsync(int id);
+}

--- a/src/PatronProPartage/Services/IUserService.cs
+++ b/src/PatronProPartage/Services/IUserService.cs
@@ -1,0 +1,9 @@
+using PatronProPartage.Models;
+
+namespace PatronProPartage.Services;
+
+public interface IUserService
+{
+    Task<User?> GetByIdAsync(int id);
+    Task AddAsync(User user);
+}

--- a/src/PatronProPartage/Services/InMemoryPatronService.cs
+++ b/src/PatronProPartage/Services/InMemoryPatronService.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Linq;
+using PatronProPartage.Models;
+
+namespace PatronProPartage.Services;
+
+public class InMemoryPatronService : IPatronService
+{
+    private static readonly List<Pattern> _patterns = new();
+
+    public Task<List<Pattern>> GetAllAsync()
+    {
+        return Task.FromResult(_patterns.ToList());
+    }
+
+    public Task<Pattern?> GetByIdAsync(int id)
+    {
+        var pattern = _patterns.FirstOrDefault(p => p.Id == id);
+        return Task.FromResult(pattern);
+    }
+
+    public Task AddAsync(Pattern pattern)
+    {
+        pattern.Id = _patterns.Count == 0 ? 1 : _patterns.Max(p => p.Id) + 1;
+        _patterns.Add(pattern);
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateAsync(Pattern pattern)
+    {
+        var index = _patterns.FindIndex(p => p.Id == pattern.Id);
+        if (index >= 0)
+        {
+            _patterns[index] = pattern;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(int id)
+    {
+        var existing = _patterns.FirstOrDefault(p => p.Id == id);
+        if (existing != null)
+        {
+            _patterns.Remove(existing);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/src/PatronProPartage/Services/InMemoryUserService.cs
+++ b/src/PatronProPartage/Services/InMemoryUserService.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Linq;
+using PatronProPartage.Models;
+
+namespace PatronProPartage.Services;
+
+public class InMemoryUserService : IUserService
+{
+    private readonly List<User> _users = new();
+
+    public Task AddAsync(User user)
+    {
+        user.Id = _users.Count + 1;
+        _users.Add(user);
+        return Task.CompletedTask;
+    }
+
+    public Task<User?> GetByIdAsync(int id)
+    {
+        var user = _users.FirstOrDefault(u => u.Id == id);
+        return Task.FromResult(user);
+    }
+}

--- a/src/PatronProPartage/Services/LocalFileStorageService.cs
+++ b/src/PatronProPartage/Services/LocalFileStorageService.cs
@@ -1,0 +1,30 @@
+using System.IO;
+namespace PatronProPartage.Services;
+
+public class LocalFileStorageService : IFileStorageService
+{
+    private readonly string _basePath = "D:/CoutureShare/PatronsStorage";
+
+    public Task SaveAsync(string path, Stream content)
+    {
+        string fullPath = Path.Combine(_basePath, path);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        using var fileStream = File.Create(fullPath);
+        return content.CopyToAsync(fileStream);
+    }
+
+    public Task<Stream?> GetAsync(string path)
+    {
+        string fullPath = Path.Combine(_basePath, path);
+        if (!File.Exists(fullPath)) return Task.FromResult<Stream?>(null);
+        Stream fileStream = File.OpenRead(fullPath);
+        return Task.FromResult<Stream?>(fileStream);
+    }
+
+    public Task DeleteAsync(string path)
+    {
+        string fullPath = Path.Combine(_basePath, path);
+        if (File.Exists(fullPath)) File.Delete(fullPath);
+        return Task.CompletedTask;
+    }
+}

--- a/src/PatronProPartage/Shared/MainLayout.razor
+++ b/src/PatronProPartage/Shared/MainLayout.razor
@@ -1,0 +1,15 @@
+@inherits LayoutComponentBase
+
+<MudLayout>
+    <MudAppBar Color="Color.Primary" Elevation="1">
+        <MudText Typo="Typo.h6">PatronProPartage</MudText>
+    </MudAppBar>
+
+    <MudDrawer Open="true" ClipMode="DrawerClipMode.Never">
+        <NavMenu />
+    </MudDrawer>
+
+    <MudMainContent>
+        @Body
+    </MudMainContent>
+</MudLayout>

--- a/src/PatronProPartage/Shared/MainLayout.razor
+++ b/src/PatronProPartage/Shared/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 
+<MudThemeProvider>
 <MudLayout>
     <MudAppBar Color="Color.Primary" Elevation="1">
         <MudText Typo="Typo.h6">PatronProPartage</MudText>
@@ -13,3 +14,4 @@
         @Body
     </MudMainContent>
 </MudLayout>
+</MudThemeProvider>

--- a/src/PatronProPartage/Shared/NavMenu.razor
+++ b/src/PatronProPartage/Shared/NavMenu.razor
@@ -1,0 +1,6 @@
+<MudNavMenu>
+    <MudNavLink Href="/" Icon="icons:fas fa-home">Accueil</MudNavLink>
+    <MudNavLink Href="/patternform" Icon="icons:fas fa-plus">Ajouter un patron</MudNavLink>
+    <MudNavLink Href="/patterns" Icon="icons:fas fa-list">Tous les patrons</MudNavLink>
+    <MudNavLink Href="/profile" Icon="icons:fas fa-user">Mon profil</MudNavLink>
+</MudNavMenu>

--- a/src/PatronProPartage/_Imports.razor
+++ b/src/PatronProPartage/_Imports.razor
@@ -1,0 +1,14 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components
+@using Microsoft.JSInterop
+@using MudBlazor
+@using PatronProPartage
+@using PatronProPartage.Shared
+@using PatronProPartage.Models
+@using PatronProPartage.Services

--- a/src/PatronProPartage/wwwroot/css/site.css
+++ b/src/PatronProPartage/wwwroot/css/site.css
@@ -1,0 +1,3 @@
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}


### PR DESCRIPTION
## Summary
- extend `PatternForm` with MudBlazor controls for categories, sizes and file upload
- show an image preview and save pattern via `IPatronService`
- add a placeholder profile page
- update menu links to home, add pattern, all patterns and profile

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841cbaf4e18832490829fb0c63e56d5